### PR TITLE
Add frozen_string_literals for older Ruby versions and other rubocop fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2024-12-26
+## [0.2.1] - 2025-09-27
+
+### Fixed
+- Incorrect active_support dependency version range
+
+## [0.2.0] - 2025-09-27 (yanked due to issue installing active_support versions. Use 0.2.1 instead)
 
 ### Added
+- Support for xml, conf and ini files in addition to the yaml and json formats 
 - Multi-directory configuration support - load and merge configs from multiple directories
 - Directory precedence system - earlier directories override later ones
 - Mixed file format support - YAML, JSON, and other formats in the same project

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec
 
-# Development dependencies
-gem 'minitest', '~> 5.20'
-gem 'mutex_m'
-gem 'rake'
-gem 'rubocop', '~> 1.50'
-gem 'rubocop-minitest', '~> 0.35'
-gem 'rubocop-rake', '~> 0.6'
+group :development, :test do
+  gem 'minitest', '~> 5.20', '>= 5.20.0'
+  gem 'mutex_m', '~> 0.3.0'
+  gem 'rake', '~> 13.0', '>= 13.0.0'
+  gem 'rubocop', '~> 1.50'
+  gem 'rubocop-minitest', '~> 0.30'
+  gem 'rubocop-rake', '~> 0.6'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|

--- a/config_files.gemspec
+++ b/config_files.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'config_files/version'

--- a/lib/config_files.rb
+++ b/lib/config_files.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'config_files/file_factory'
 require 'config_files/loader_factory'
 require 'config_files/loaders'

--- a/lib/config_files/file_factory.rb
+++ b/lib/config_files/file_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ConfigFiles
   class FileFactory
     class << self

--- a/lib/config_files/loader_factory.rb
+++ b/lib/config_files/loader_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ConfigFiles
   class LoaderFactory
     class << self

--- a/lib/config_files/loaders.rb
+++ b/lib/config_files/loaders.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'loaders/json'
 require_relative 'loaders/yaml'
 require_relative 'loaders/conf'

--- a/lib/config_files/loaders/default.rb
+++ b/lib/config_files/loaders/default.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 ConfigFiles::Loaders::Default = ConfigFiles::Loaders::Yaml

--- a/lib/config_files/loaders/json.rb
+++ b/lib/config_files/loaders/json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module ConfigFiles

--- a/lib/config_files/loaders/yaml.rb
+++ b/lib/config_files/loaders/yaml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ConfigFiles
   module Loaders
     class Yaml

--- a/lib/config_files/version.rb
+++ b/lib/config_files/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ConfigFiles
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/lib/config_files/version.rb
+++ b/lib/config_files/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ConfigFiles
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.2.0'
 end

--- a/lib/meta.rb
+++ b/lib/meta.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # @author Paul McKibbin based on meta definitions by _why_the_lucky_stiff_
 module Meta
   def meta_self

--- a/test/config_files_test.rb
+++ b/test/config_files_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.push(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'minitest/autorun'
 require 'config_files'
@@ -11,7 +13,7 @@ class Dummy2 < Dummy
   config_directories config: ['test/etc', 'test/nofiles/etc']
   class << self
     def config_key
-      "config"
+      'config'
     end
   end
 end


### PR DESCRIPTION
Real preparation for the release. Because of a bad merge of the gemspec file, I'm going to bump this to 0.2.1